### PR TITLE
load german language for babel

### DIFF
--- a/btexmat/oscBibDataCheckEn.tex
+++ b/btexmat/oscBibDataCheckEn.tex
@@ -31,7 +31,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/btexmat/oscBibRevAllEn.tex
+++ b/btexmat/oscBibRevAllEn.tex
@@ -31,7 +31,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/btexmat/oscBibRevCopiedButNotRead.tex
+++ b/btexmat/oscBibRevCopiedButNotRead.tex
@@ -31,7 +31,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/btexmat/oscBibRevNextAction.tex
+++ b/btexmat/oscBibRevNextAction.tex
@@ -31,7 +31,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/btexmat/oscBibRevResourcesEn.tex
+++ b/btexmat/oscBibRevResourcesEn.tex
@@ -31,7 +31,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/extracts/arlBriVol2004a.tex
+++ b/extracts/arlBriVol2004a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 
 %language specific quoting signs

--- a/extracts/breGlaGra2008a.tex
+++ b/extracts/breGlaGra2008a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/extracts/bruHarPicCreFieHen2004a.tex
+++ b/extracts/bruHarPicCreFieHen2004a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 
 %language specific quoting signs

--- a/extracts/eckl2004a.tex
+++ b/extracts/eckl2004a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 
 %language specific quoting signs

--- a/extracts/euler2006a.tex
+++ b/extracts/euler2006a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 
 %language specific quoting signs

--- a/extracts/ifross2005a.tex
+++ b/extracts/ifross2005a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 
 %language specific quoting signs

--- a/extracts/jaeMet2002a06a11a.tex
+++ b/extracts/jaeMet2002a06a11a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 
 %language specific quoting signs

--- a/extracts/kaes2008a.tex
+++ b/extracts/kaes2008a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/extracts/koglin2007a.tex
+++ b/extracts/koglin2007a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 
 %language specific quoting signs

--- a/extracts/kreutzer2008a.tex
+++ b/extracts/kreutzer2008a.tex
@@ -31,7 +31,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 
 %language specific quoting signs

--- a/extracts/kreutzer2008b.tex
+++ b/extracts/kreutzer2008b.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 
 %language specific quoting signs

--- a/extracts/kreutzer2008c.tex
+++ b/extracts/kreutzer2008c.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 
 %language specific quoting signs

--- a/extracts/mundhenke2007a.tex
+++ b/extracts/mundhenke2007a.tex
@@ -31,7 +31,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 
 %language specific quoting signs

--- a/extracts/oberhem2008a.tex
+++ b/extracts/oberhem2008a.tex
@@ -31,7 +31,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 %language specific quoting signs
 %default for language emglish is american style of quotes

--- a/extracts/renVetRexKet2005a.tex
+++ b/extracts/renVetRexKet2005a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 
 %language specific quoting signs

--- a/extracts/sebald2008a.tex
+++ b/extracts/sebald2008a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 
 %language specific quoting signs

--- a/extracts/seeKra2008a.tex
+++ b/extracts/seeKra2008a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 
 %language specific quoting signs

--- a/extracts/spindler2004a.tex
+++ b/extracts/spindler2004a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 
 %language specific quoting signs

--- a/extracts/stallman1984a.tex
+++ b/extracts/stallman1984a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/extracts/stallman1994a.tex
+++ b/extracts/stallman1994a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/extracts/stallman1996a.tex
+++ b/extracts/stallman1996a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/extracts/stallman1996b.tex
+++ b/extracts/stallman1996b.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/extracts/stallman1996c.tex
+++ b/extracts/stallman1996c.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/extracts/stallman1998a.tex
+++ b/extracts/stallman1998a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/extracts/stallman1999a.tex
+++ b/extracts/stallman1999a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/extracts/stallman2000a.tex
+++ b/extracts/stallman2000a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/extracts/stallman2001a.tex
+++ b/extracts/stallman2001a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/extracts/stallman2002b.tex
+++ b/extracts/stallman2002b.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/extracts/suchomski2011a.tex
+++ b/extracts/suchomski2011a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 
 %language specific quoting signs

--- a/extracts/taubert2006a.tex
+++ b/extracts/taubert2006a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 
 %language specific quoting signs

--- a/extracts/viesel2006a.tex
+++ b/extracts/viesel2006a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 
 %language specific quoting signs

--- a/extracts/vwdjDebVEee2003a.tex
+++ b/extracts/vwdjDebVEee2003a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/extracts/widmer2003a.tex
+++ b/extracts/widmer2003a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 
 %language specific quoting signs

--- a/extracts/williams2002a.tex
+++ b/extracts/williams2002a.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/snippets/oscSnippetFrame.tex
+++ b/snippets/oscSnippetFrame.tex
@@ -25,7 +25,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/templates/oscBibDataCheckEn.tex
+++ b/templates/oscBibDataCheckEn.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs

--- a/templates/oscExtractTplDe.tex
+++ b/templates/oscExtractTplDe.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[english, ngerman]{babel}
+\usepackage[english, german, ngerman]{babel}
 \selectlanguage{ngerman}
 
 %language specific quoting signs

--- a/templates/oscExtractTplEn.tex
+++ b/templates/oscExtractTplEn.tex
@@ -32,7 +32,7 @@
 
 %%% (2) language specific configurations %%%
 \usepackage[]{a4,ngerman}
-\usepackage[ngerman, english]{babel}
+\usepackage[ngerman, german, english]{babel}
 \selectlanguage{english}
 
 %language specific quoting signs


### PR DESCRIPTION
Some references declare `language=german`.
As the old german language is not loaded by babel this results in a compilation
error.

Changes have been made to all .tex files with:

`$ find -name '*tex' -type f | xargs sed -i -r 's/([[:alnum:]]*), ([[:alnum:]]*)\]\{babel\}/\1, german, \2\]\{babel\}/'`
